### PR TITLE
Playground-389: Pouvoir supprimer une image uploadée

### DIFF
--- a/src/PlaygroundGame/Form/Admin/Game.php
+++ b/src/PlaygroundGame/Form/Admin/Game.php
@@ -84,6 +84,14 @@ class Game extends ProvidesEventsForm
                 'value' => ''
             )
         ));
+        $this->add(array(
+            'name' => 'deleteMainImage',
+            'type' => 'Zend\Form\Element\Hidden',
+            'attributes' => array(
+                'value' => '',
+                'class' => 'delete_main_image',
+            ),
+        ));
 
         // Adding an empty upload field to be able to correctly handle this on
         // the service side.
@@ -102,6 +110,14 @@ class Game extends ProvidesEventsForm
             'attributes' => array(
                 'value' => ''
             )
+        ));
+        $this->add(array(
+            'name' => 'deleteSecondImage',
+            'type' => 'Zend\Form\Element\Hidden',
+            'attributes' => array(
+                'value' => '',
+                'class' => 'delete_second_image',
+            ),
         ));
 
         $this->add(array(
@@ -399,6 +415,14 @@ class Game extends ProvidesEventsForm
                         'value' => ''
                 )
         ));
+        $this->add(array(
+            'name' => 'deleteFbPageTabImage',
+            'type' => 'Zend\Form\Element\Hidden',
+            'attributes' => array(
+                'value' => '',
+                'class' => 'delete_fb_page_tab_image',
+            ),
+        ));
 
         $this->add(array(
             'type' => 'Zend\Form\Element\Textarea',
@@ -545,6 +569,14 @@ class Game extends ProvidesEventsForm
             'attributes' => array(
                 'value' => ''
             )
+        ));
+        $this->add(array(
+            'name' => 'deleteFbShareImage',
+            'type' => 'Zend\Form\Element\Hidden',
+            'attributes' => array(
+                'value' => '',
+                'class' => 'delete_fb_share_image',
+            ),
         ));
 
         $this->add(array(

--- a/src/PlaygroundGame/Form/Admin/InstantWin.php
+++ b/src/PlaygroundGame/Form/Admin/InstantWin.php
@@ -142,5 +142,13 @@ class InstantWin extends Game
                     'value' => ''
                 )
         ));
+        $this->add(array(
+            'name' => 'deleteScratchcardImage',
+            'type' => 'Zend\Form\Element\Hidden',
+            'attributes' => array(
+                'value' => '',
+                'class' => 'delete_scratch_image',
+            )
+        ));
     }
 }

--- a/src/PlaygroundGame/Form/Admin/QuizQuestion.php
+++ b/src/PlaygroundGame/Form/Admin/QuizQuestion.php
@@ -201,8 +201,16 @@ class QuizQuestion extends ProvidesEventsForm
                 'name' => 'image',
                 'type'  => 'Zend\Form\Element\Hidden',
                 'attributes' => array(
-                        'value' => '',
+                    'value' => '',
                 ),
+        ));
+        $this->add(array(
+                'name' => 'delete_image',
+                'type' => 'Zend\Form\Element\Hidden',
+                'attributes' => array(
+        	        'value' => '',
+                    'class' => 'delete_image',       
+                ),   
         ));
 
         $quizAnswerFieldset = new QuizAnswerFieldset(null,$serviceManager,$translator);

--- a/src/PlaygroundGame/Service/Game.php
+++ b/src/PlaygroundGame/Service/Game.php
@@ -321,12 +321,30 @@ class Game extends EventProvider implements ServiceManagerAwareInterface
             $game->setMainImage($media_url . $data['uploadMainImage']['name']);
             ErrorHandler::stop(true);
         }
+        
+        if(isset($data['deleteMainImage']) && $data['deleteMainImage'] && empty($data['uploadMainImage']['tmp_name'])) {
+            ErrorHandler::start();
+            $image = $game->getMainImage();
+            $image = str_replace($media_url, '', $image);
+            unlink($path . $image);
+            $game->setMainImage(null);
+            ErrorHandler::stop(true);
+        }
 
         if (!empty($data['uploadSecondImage']['tmp_name'])) {
             ErrorHandler::start();
 			$data['uploadSecondImage']['name'] = $this->fileNewname($path, $game->getId() . "-" . $data['uploadSecondImage']['name']);
             move_uploaded_file($data['uploadSecondImage']['tmp_name'], $path . $data['uploadSecondImage']['name']);
             $game->setSecondImage($media_url . $data['uploadSecondImage']['name']);
+            ErrorHandler::stop(true);
+        }
+        
+        if(isset($data['deleteSecondImage']) && $data['deleteSecondImage'] && empty($data['uploadSecondImage']['tmp_name'])) {
+            ErrorHandler::start();
+            $image = $game->getSecondImage();
+            $image = str_replace($media_url, '', $image);
+            unlink($path .$image);
+            $game->setSecondImage(null);
             ErrorHandler::stop(true);
         }
 
@@ -344,6 +362,15 @@ class Game extends EventProvider implements ServiceManagerAwareInterface
             $game->setFbShareImage($media_url . $data['uploadFbShareImage']['name']);
             ErrorHandler::stop(true);
         }
+        
+        if(isset($data['deleteFbShareImage']) && $data['deleteFbShareImage'] && empty($data['uploadFbShareImage']['tmp_name'])) {
+            ErrorHandler::start();
+            $image = $game->getFbShareImage();
+            $image = str_replace($media_url, '', $image);
+            unlink($path .$image);
+            $game->setFbShareImage(null);
+            ErrorHandler::stop(true);
+        }
 
         if (!empty($data['uploadFbPageTabImage']['tmp_name'])) {
             ErrorHandler::start();
@@ -354,6 +381,15 @@ class Game extends EventProvider implements ServiceManagerAwareInterface
             //move_uploaded_file($data['uploadFbPageTabImage']['tmp_name'], $path . $game->getId() . "-" . $data['uploadFbPageTabImage']['name']);
 
             $game->setFbPageTabImage($media_url . $game->getId() . "-" . $data['uploadFbPageTabImage']['name']);
+            ErrorHandler::stop(true);
+        }
+        
+        if(isset($data['deleteFbPageTabImage']) && $data['deleteFbPageTabImage'] && empty($data['uploadFbPageTabImage']['tmp_name'])) {
+            ErrorHandler::start();
+            $image = $game->getFbPageTabImage();
+            $image = str_replace($media_url, '', $image);
+            unlink($path .$image);
+            $game->setFbPageTabImage(null);
             ErrorHandler::stop(true);
         }
 

--- a/src/PlaygroundGame/Service/InstantWin.php
+++ b/src/PlaygroundGame/Service/InstantWin.php
@@ -70,10 +70,12 @@ class InstantWin extends Game implements ServiceManagerAwareInterface
         $game = parent::edit($data, $game, $formClass);
 
         if ($game) {
+
+            $path = $this->getOptions()->getMediaPath() . DIRECTORY_SEPARATOR;
+            $media_url = $this->getOptions()->getMediaUrl() . '/';
+            
             if (!empty($data['uploadScratchcardImage']['tmp_name'])) {
 
-                $path = $this->getOptions()->getMediaPath() . DIRECTORY_SEPARATOR;
-                $media_url = $this->getOptions()->getMediaUrl() . '/';
 
                 ErrorHandler::start();
                 $data['uploadScratchcardImage']['name'] = $this->fileNewname($path, $game->getId() . "-" . $data['uploadScratchcardImage']['name']);
@@ -82,6 +84,16 @@ class InstantWin extends Game implements ServiceManagerAwareInterface
                 ErrorHandler::stop(true);
 
                 $game = $this->getGameMapper()->update($game);
+            }
+            
+            if(isset($data['deleteScratchcardImage']) && $data['deleteScratchcardImage'] && empty($data['uploadScratchcardImage']['tmp_name'])) {
+                
+                ErrorHandler::start();
+                $image = $game->getScratchcardImage();
+                $image = str_replace($media_url, '', $image);
+                unlink($path .$image);
+                $game->setScratchcardImage(null);
+                ErrorHandler::stop(true);
             }
 
             if ($game->getOccurrenceNumber() && $game->getScheduleOccurrenceAuto()) {

--- a/src/PlaygroundGame/Service/Quiz.php
+++ b/src/PlaygroundGame/Service/Quiz.php
@@ -116,6 +116,15 @@ class Quiz extends Game implements ServiceManagerAwareInterface
             $question->setImage($media_url . $data['upload_image']['name']);
             ErrorHandler::stop(true);
         }
+        
+        if($data['delete_image'] && empty($data['upload_image']['tmp_name'])) {
+            ErrorHandler::start();
+            $image = $question->getImage();
+            $image = str_replace($media_url, '', $image);
+            unlink($path .$image);
+            $question->setImage(null);
+            ErrorHandler::stop(true);
+        }
 
         // Max points and correct answers calculation for the question
         $question = $this->calculateMaxAnswersQuestion($question);


### PR DESCRIPTION
On peut désormais supprimer une image uploadée sur :
- le formulaire d'édition d'un jeu -> image de couverture, image secondaire, images FB et images de grattage
- l'édition d'une question de quiz
